### PR TITLE
Get column data from DataTable with fnGetData directly

### DIFF
--- a/media/js/ColumnFilterWidgets.js
+++ b/media/js/ColumnFilterWidgets.js
@@ -54,8 +54,7 @@
 		
 		for (var i=0,c=aiRows.length; i<c; i++) {
 			iRow = aiRows[i];
-			var aData = this.fnGetData(iRow);
-			var sValue = aData[iColumn];
+			var sValue = this.fnGetData(iRow, iColumn);
 			
 			// ignore empty values?
 			if (bIgnoreEmpty == true && sValue.length == 0) continue;


### PR DESCRIPTION
This approach works for both array and object data binding for
DataTable's aaData.

Old approach (getting row data and accessing column data via [iColumn])
doesn't work when aaData for DataTable is bound to array of objects.
