### PR TITLE
Changed variable from global to local

### DIFF
--- a/media/js/ColumnFilterWidgets.js
+++ b/media/js/ColumnFilterWidgets.js
@@ -53,7 +53,7 @@
 		var asResultData = new Array();
 		
 		for (var i=0,c=aiRows.length; i<c; i++) {
-			iRow = aiRows[i];
+			var iRow = aiRows[i];
 			var sValue = this.fnGetData(iRow, iColumn);
 			
 			// ignore empty values?


### PR DESCRIPTION
Changed variable iRow (ln 56) in media/js/ColumnFilterWidgets.js from global to local. I didn't see a reason for it to be global, since the only reference to it that I could find is on the very next line. Let me know if that was wrong! I noticed it when trying to clean up the global namespace for a project I'm working on that uses DataTables and this plugin.
